### PR TITLE
bug: Webhook의 각 event 클래스 의존성 주입 문제 해결 (#25)

### DIFF
--- a/src/main/java/com/sharetreats/chatbot/module/controller/WebhookController.java
+++ b/src/main/java/com/sharetreats/chatbot/module/controller/WebhookController.java
@@ -3,6 +3,7 @@ package com.sharetreats.chatbot.module.controller;
 import com.sharetreats.chatbot.module.controller.webhook.SendPaymentResultMessage;
 import com.sharetreats.chatbot.module.controller.webhook.SendProductsOfBrand;
 import com.sharetreats.chatbot.module.controller.webhook.SendWelcomeMessage;
+import lombok.RequiredArgsConstructor;
 import org.json.JSONObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,7 +24,12 @@ import static com.sharetreats.chatbot.module.controller.WebhookController.InputK
  * @Webhook_URL_Endpoint: "/viber/bot/webhook"
  */
 @RestController
+@RequiredArgsConstructor
 public class WebhookController {
+
+    private final SendWelcomeMessage sendWelcomeMessage;
+    private final SendPaymentResultMessage sendPaymentResultMessage;
+    private final SendProductsOfBrand sendProductsOfBrand;
 
     /**
      * Webhook CallBack Data 를 받는 `MAIN API`
@@ -33,8 +39,12 @@ public class WebhookController {
     @PostMapping("/viber/bot/webhook")
     public ResponseEntity<?> webhook(@RequestBody String callback) {
         String event = getEventValueToCallback(callback);
-        if (event.equals(CONVERSATION_STARTED)) return SendWelcomeMessage.execute();
-        if (event.equals(MESSAGE)) return sendResponseByTextInMessage(callback);
+
+        if (event.equals(CONVERSATION_STARTED))
+            return sendWelcomeMessage.execute(callback);
+        if (event.equals(MESSAGE))
+            return sendResponseByTextInMessage(callback);
+
         return null;
     }
 
@@ -44,10 +54,13 @@ public class WebhookController {
      * @param callback
      * @return ResponseEntity
      */
-    private static ResponseEntity<?> sendResponseByTextInMessage(String callback) {
+    private ResponseEntity<?> sendResponseByTextInMessage(String callback) {
         String text = getTextToMessage(callback);
-        if (isContains(text, BUY_USE_POINT)) return SendPaymentResultMessage.execute(callback);
-        if (isContains(text, VIEW_PRODUCTS_OF_BRAND)) return SendProductsOfBrand.execute(callback);
+        if (isContains(text, BUY_USE_POINT))
+            return sendPaymentResultMessage.execute(callback);
+        if (isContains(text, VIEW_PRODUCTS_OF_BRAND))
+            return sendProductsOfBrand.execute(callback);
+
         throw new IllegalArgumentException("어떠한 이벤트에도 해당하지 않는 문자입니다.");
     }
 

--- a/src/main/java/com/sharetreats/chatbot/module/controller/webhook/ResponseEvent.java
+++ b/src/main/java/com/sharetreats/chatbot/module/controller/webhook/ResponseEvent.java
@@ -1,0 +1,8 @@
+package com.sharetreats.chatbot.module.controller.webhook;
+
+import org.springframework.http.ResponseEntity;
+
+public abstract class ResponseEvent {
+
+    public abstract ResponseEntity<?> execute(String callback);
+}

--- a/src/main/java/com/sharetreats/chatbot/module/controller/webhook/SendPaymentResultMessage.java
+++ b/src/main/java/com/sharetreats/chatbot/module/controller/webhook/SendPaymentResultMessage.java
@@ -1,11 +1,23 @@
 package com.sharetreats.chatbot.module.controller.webhook;
 
 import com.sharetreats.chatbot.module.controller.dto.WelcomeMessageDto;
+import com.sharetreats.chatbot.module.service.ServiceTest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
 
-public class SendPaymentResultMessage {
+/**
+ * 예시를 위한 클래스입니다.
+ */
+@RequiredArgsConstructor
+@Component
+public class SendPaymentResultMessage extends ResponseEvent {
 
-    public static ResponseEntity<?> execute(String callback) {
+    private final ServiceTest service;
+
+    @Override
+    public ResponseEntity<?> execute(String callback) {
+        service.test();
         return ResponseEntity.ok(
                 WelcomeMessageDto.builder()
                         .text("예시를 위한 dto 입니다. 확인 후 삭제해주세요.")

--- a/src/main/java/com/sharetreats/chatbot/module/controller/webhook/SendProductsOfBrand.java
+++ b/src/main/java/com/sharetreats/chatbot/module/controller/webhook/SendProductsOfBrand.java
@@ -1,10 +1,21 @@
 package com.sharetreats.chatbot.module.controller.webhook;
 
+import com.sharetreats.chatbot.module.service.ServiceTest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
 
-public class SendProductsOfBrand {
-    public static ResponseEntity<?> execute(String callback) {
+/**
+ * 예시를 위한 클래스입니다.
+ */
+@RequiredArgsConstructor
+@Component
+public class SendProductsOfBrand extends ResponseEvent {
 
-        return null;
+    private final ServiceTest service;
+
+    public ResponseEntity<?> execute(String callback) {
+        service.test();
+        return ResponseEntity.ok("테스트");
     }
 }

--- a/src/main/java/com/sharetreats/chatbot/module/controller/webhook/SendWelcomeMessage.java
+++ b/src/main/java/com/sharetreats/chatbot/module/controller/webhook/SendWelcomeMessage.java
@@ -1,11 +1,23 @@
 package com.sharetreats.chatbot.module.controller.webhook;
 
 import com.sharetreats.chatbot.module.controller.dto.Dto;
+import com.sharetreats.chatbot.module.service.ServiceTest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
 
-public class SendWelcomeMessage {
+/**
+ * 예시를 위한 클래스입니다.
+ */
+@RequiredArgsConstructor
+@Component
+public class SendWelcomeMessage extends ResponseEvent {
 
-    public static ResponseEntity<?> execute() {
+    private final ServiceTest service;
+
+    @Override
+    public ResponseEntity<?> execute(String callback) {
+        service.test();
         return ResponseEntity.ok(
                 Dto.builder()
                         .text("예시를 위한 dto 입니다. 확인 후 삭제해주세요.")

--- a/src/main/java/com/sharetreats/chatbot/module/service/ServiceTest.java
+++ b/src/main/java/com/sharetreats/chatbot/module/service/ServiceTest.java
@@ -1,0 +1,15 @@
+package com.sharetreats.chatbot.module.service;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * 주입 테스트를 위한 임의의 클래스입니다.
+ * 삭제해주세요.
+ */
+@Service
+public class ServiceTest {
+
+    public void test() {
+
+    }
+}


### PR DESCRIPTION
This closes #25 

@tlqkrus012345 @Daeell @Damm06 

이전에 작성된 형식의 webhook에서 service 주입 문제로 컴파일 시점에 발생하는 에러를 해결했습니다.

## 문제 원인

1) event, message 별로 분기된 클래스의 메서드가 static
2) component scan 대상이 아니어서 service 주입 실패

## 해결
> 디자인 패턴 중 전략 패턴을 사용하여 해결하려 함. <br>
> 이 또한 주입이 되지 않아서 역시나 문제 

- 따라서 정통법인 생성자 주입 방식으로 문제 해결
