### PR TITLE
bug: Thymeleaf bean 주입 문제로 인한 배포 실패 에러 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.json:json:20230618'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
-    implementation 'org.thymeleaf:thymeleaf:3.1.1.RELEASE'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
 
     annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
## 배포 중 발생한 문제
```
Description:
Parameter 5 of constructor in com.sharetreats.chatbot.module.service.PaymentServiceImpl required a bean of type 'org.thymeleaf.TemplateEngine' that could not be found. Action:
Consider defining a bean of type 'org.thymeleaf.TemplateEngine' in your configuration.
```

build.gradle에 주입했던 `Thymeleaf`에서 `spring-boot-starter-thymeleaf`로 변경